### PR TITLE
upgrade pebble to 3.1.4 (#1150)

### DIFF
--- a/jsplot/pom.xml
+++ b/jsplot/pom.xml
@@ -94,7 +94,7 @@
         <dependency>
             <groupId>io.pebbletemplates</groupId>
             <artifactId>pebble</artifactId>
-            <version>3.1.2</version>
+            <version>3.1.4</version>
         </dependency>
         <dependency>
             <groupId>net.tlabs-data</groupId>


### PR DESCRIPTION
Cherry picked from https://github.com/jtablesaw/tablesaw/pull/1150