### PR TITLE
Fix Table.dropDuplicateRows()

### DIFF
--- a/core/src/main/java/tech/tablesaw/api/Table.java
+++ b/core/src/main/java/tech/tablesaw/api/Table.java
@@ -983,12 +983,10 @@ public class Table extends Relation implements Iterable<Row> {
       Row oldRow = this.row(key);
       if (duplicateRows(row, oldRow)) {
         return true;
-      } else {
-        uniqueHashes.get(hash).add(row.getRowNumber());
-        return false;
       }
     }
-    return true;
+    uniqueHashes.get(hash).add(row.getRowNumber());
+    return false;
   }
 
   /** Returns only those records in this table that have no columns with missing values */

--- a/core/src/test/java/tech/tablesaw/api/FixDropDuplicatesTest.java
+++ b/core/src/test/java/tech/tablesaw/api/FixDropDuplicatesTest.java
@@ -1,0 +1,38 @@
+package tech.tablesaw.api;
+
+import java.io.File;
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.*;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import tech.tablesaw.io.csv.CsvReadOptions;
+
+class FixDropDuplicatesTest {
+
+    private static final String SOURCE_FILE_NAME = "../data/missing_values.csv";
+    private static Table testTable;
+    
+    @BeforeAll
+    static void setUpBeforeClass() throws Exception {
+        testTable = Table.read().usingOptions(CsvReadOptions
+            .builder(new File(SOURCE_FILE_NAME))
+            .missingValueIndicator("-"));    }
+
+    @Test
+    void test() throws Exception {
+        Method privateMethod = Table.class.getDeclaredMethod("isDuplicate", Row.class, Int2ObjectMap.class);
+        privateMethod.setAccessible(true);
+        Int2ObjectMap<IntArrayList> uniqueHashes = new Int2ObjectOpenHashMap<>();
+        Row row0 = testTable.row(0);
+        IntArrayList value = new IntArrayList(new int[] {1, 0});
+        uniqueHashes.put(row0.rowHash(), value);
+        boolean isDuplicate = (boolean) privateMethod.invoke(testTable, row0, uniqueHashes);
+        assertTrue(isDuplicate, "Duplicate row not found");
+    }
+
+}

--- a/core/src/test/java/tech/tablesaw/api/FixDropDuplicatesTest.java
+++ b/core/src/test/java/tech/tablesaw/api/FixDropDuplicatesTest.java
@@ -18,7 +18,7 @@ class FixDropDuplicatesTest {
     private static Table testTable;
     
     @BeforeAll
-    static void setUpBeforeClass() throws Exception {
+    static void setUpBeforeClass() {
         testTable = Table.read().usingOptions(CsvReadOptions
             .builder(new File(SOURCE_FILE_NAME))
             .missingValueIndicator("-"));    }


### PR DESCRIPTION
Thanks for contributing.

- [x] Tick to sign-off your agreement to the [Developer Certificate of Origin (DCO) 1.1](https://developercertificate.org)

## Description

Table.isDuplicate() now checks all matching rows before returning. Prevents the Table returned by dropDuplicateRows() to still contain duplicates. See https://github.com/jtablesaw/tablesaw/issues/1248

## Testing

Yes
